### PR TITLE
TokenTap.sol review

### DIFF
--- a/contracts/TokenTap.sol
+++ b/contracts/TokenTap.sol
@@ -48,8 +48,8 @@ contract TokenTap is AccessControl {
 
         if (!hasRole(UNITAP_ROLE, signer)) revert InvalidSignature();
 
-        IERC20(token).safeTransfer(user, amount);
         usedNonces[user][nonce] = true;
+        IERC20(token).safeTransfer(user, amount);
 
         emit TokensClaimed(token, user, amount, nonce);
     }


### PR DESCRIPTION
There is a reentrancy vulnerability in the `claim()` function. 

As the code stands, if the `transfer()` function on a token contract allows for execution of arbitrary code, the `claim()` function can be replayed many times with the same signed authorization, draining the contract of funds.

I've included a fix which marks the nonce of an authorization as used before `transfer()` is called.  This prevents a claim from being replayed.

Why might the code have been originally written with the `transfer()` call before marking the nonce?  Maybe it was to make sure the transfer succeeded before marking the nonce as used, but this isn't necessary. If the transfer fails, the whole call will revert, meaning the nonce will not be marked, and the user will be able to retry the claim using the same authorization, as it should be.

It may sound strange that a `transfer()` call can execute arbitrary code, but [this is exactly what caused an expensive exploit in the agave platform](https://hackmd.io/@koal/SJiDiO0bc).  Omni-bridged tokens can have arbitrary code attached to the `transfer` function by the person who bridged the tokens. 